### PR TITLE
Add pagination loop to handle additional entries in a folder.

### DIFF
--- a/dropbox_download.py
+++ b/dropbox_download.py
@@ -3,9 +3,26 @@ import json
 import argparse
 import os
 
+ERROR_EXIT_CODE = 1
+SUCCESS_STATUS_CODES = [200, 201]
+
+
+def guard_error_response(response: requests.models.Response):
+    """
+    If response is a not a success status code, print response and quit out of program.
+
+    This currently mainly handles the case when access tokens may expire while running program.
+    If program doesn't quit after error response, the file saved will be contents of the error.
+    """
+    if response.status_code not in SUCCESS_STATUS_CODES:
+        print(f"Unexpected error in response. Status code: {response.status_code}. Error: {response.text}")
+        quit(ERROR_EXIT_CODE)
+
+
 def main(args):
     # Define the API URLs
     list_folder_url = "https://api.dropboxapi.com/2/files/list_folder"
+    list_folder_continue_url = "https://api.dropboxapi.com/2/files/list_folder/continue"
     get_shared_link_file_url = "https://content.dropboxapi.com/2/sharing/get_shared_link_file"
 
     # Access token from arguments
@@ -28,6 +45,7 @@ def main(args):
 
     print("Fetching file list...")
     response = requests.post(list_folder_url, json=list_folder_params, headers=headers)
+    guard_error_response(response)
     data = response.json()
 
     # If verbose mode is on, print the whole response data
@@ -35,6 +53,24 @@ def main(args):
         print("Verbose info: ", data)
 
     entries = data.get("entries", [])
+
+    # Value that determines if there are more entries available
+    has_more = data.get("has_more")
+
+    # Value used to make pagination request
+    cursor = data.get("cursor")
+
+    # While there are more entries in folder, paginate and continue to fetch all entries
+    while has_more:
+        # Parameters for list folder pagination request
+        list_folder_continue_params = {"cursor": cursor}
+        response = requests.post(list_folder_continue_url, json=list_folder_continue_params, headers=headers)
+        guard_error_response(response)
+        data = response.json()
+
+        entries.extend(data.get("entries", []))
+        has_more = data.get("has_more")
+        cursor = data.get("cursor")
 
     if len(entries) > 0:
         total_files = len(entries) if args.count is None else min(len(entries), args.count)
@@ -66,6 +102,8 @@ def main(args):
             }
 
             response = requests.post(get_shared_link_file_url, headers=headers)
+            guard_error_response(response)
+
             content = response.content
 
             with open(download_path, "wb") as f:


### PR DESCRIPTION
## Context
When listing entries in folder with the [Dropbox API list folder](https://api.dropboxapi.com/2/files/list_folder ) there is a maximum limit of 500 entries returned in a single request.

This means the current state of the script will not download all entries in a Dropbox folder if it contains more than 500 entries.

## Changes
* Extend the script to handle pagination.
* Add in error handling of responses. Currently this prints and ends the script immediately if there is not a success status code. This was added to handle the case when access tokens may expire mid way through a script running. Previously the script did not exit gracefully when running into such cases, which resulted in files saved with error messages as its content 

## How pagination works
From the initial request to list folders if the value of `has_more` is `true`, this indicates there are additional entries in the folder and additional pagination requests are required. To fetch additional entries the API `https://api.dropboxapi.com/2/files/list_folder/continue` is used which requires `cursor` as a parameter. This value is derived from the previous list folder request or previous pagination request.